### PR TITLE
Fix corrupted state machine resource

### DIFF
--- a/addons/imjp94.yafsm/scenes/StateMachineEditor.gd
+++ b/addons/imjp94.yafsm/scenes/StateMachineEditor.gd
@@ -179,6 +179,9 @@ func _on_state_machine_changed(new_state_machine):
 	select_layer(root_layer)
 	if new_state_machine:
 		current_layer.state_machine = state_machine
+		var validated = StateMachine.validate(new_state_machine)
+		if validated:
+			print("gd-YAFSM: Corrupted StateMachine Resource fixed, save to apply the fix.")
 		draw_graph()
 		check_has_entry()
 

--- a/addons/imjp94.yafsm/scenes/flowchart/FlowChart.gd
+++ b/addons/imjp94.yafsm/scenes/flowchart/FlowChart.gd
@@ -410,26 +410,26 @@ func _gui_input(event):
 					if _current_connection:
 						# Connection end
 						var from = _current_connection.from_node.name
-						if hit_node is FlowChartNode and _request_connect_to(hit_node.name if hit_node else null):
+						var to = hit_node.name if hit_node else null
+						if hit_node is FlowChartNode and _request_connect_to(to) and from != to:
 							# Connection success
 							var line
-							var to = hit_node.name
 							if _current_connection.to_node:
 								# Reconnection
 								line = disconnect_node(from, _current_connection.to_node.name)
 								_current_connection.to_node = hit_node
 								_on_node_reconnect_end(from, to)
+								connect_node(from, to, line)
 							else:
 								# New Connection
 								current_layer.content_lines.remove_child(_current_connection.line)
 								line = _current_connection.line
 								_current_connection.to_node = hit_node
-							connect_node(from, to, line)
+								connect_node(from, to, line)
 						else:
 							# Connection failed
 							if _current_connection.to_node:
 								# Reconnection
-								var to = _current_connection.to_node.name
 								_current_connection.join()
 								_on_node_reconnect_failed(from, name)
 							else:


### PR DESCRIPTION
Fix possible to reconnect to self which will leads to corrupted `StateMachine` `Resource`(#5 ) & Add validate() function to identify and fix corrupted `StateMachine` `Resource` when loaded in editor, to handle potential corrupted `StateMachine` `Resource` (#6 )

Screenshots of corrupted being fixed and printing warnings:
![Annotation 2021-03-10 212419](https://user-images.githubusercontent.com/11486079/110636524-50535880-81e7-11eb-9000-005c2f8f9fc9.jpg)
![Annotation 2021-03-10 212547](https://user-images.githubusercontent.com/11486079/110636534-521d1c00-81e7-11eb-8493-c727634d9044.jpg)

Fixes #5, Fixes #6 