### PR TITLE
[Fix #32] Fix StateMachinePlayer restart()

### DIFF
--- a/addons/imjp94.yafsm/src/StateMachinePlayer.gd
+++ b/addons/imjp94.yafsm/src/StateMachinePlayer.gd
@@ -182,7 +182,7 @@ func restart(is_active=true, preserve_params=false):
 	reset()
 	set_active(is_active)
 	if not preserve_params:
-		clear_param(false)
+		clear_param("", false)
 	start()
 
 # Update player to, first initiate transition, then call _on_updated, finally emit "update" signal, delta will be given based on process_mode.


### PR DESCRIPTION
Just adding the missing empty param for the path on restart().