### PR TITLE
Fixes for flowchart grid and popup menus

### DIFF
--- a/addons/imjp94.yafsm/assets/fonts/sans_serif.tres
+++ b/addons/imjp94.yafsm/assets/fonts/sans_serif.tres
@@ -1,0 +1,5 @@
+[gd_resource type="SystemFont" format=3 uid="uid://dmcxm8gxsonbq"]
+
+[resource]
+font_names = PackedStringArray("Sans-Serif")
+multichannel_signed_distance_field = true

--- a/addons/imjp94.yafsm/scenes/StateMachineEditor.gd
+++ b/addons/imjp94.yafsm/scenes/StateMachineEditor.gd
@@ -220,9 +220,15 @@ func _on_state_node_context_menu_index_pressed(index):
 		1: # Duplicate
 			duplicate_nodes(current_layer, [_context_node])
 			_context_node = null
-		2: # Separator
+		2: # Delete
+			remove_node(current_layer, _context_node.name)
+			for connection_pair in current_layer.get_connection_list():
+				if connection_pair.from == _context_node.name or connection_pair.to == _context_node.name:
+					disconnect_node(current_layer, connection_pair.from, connection_pair.to).queue_free()
 			_context_node = null
-		3: # Convert
+		3: # Separator
+			_context_node = null
+		4: # Convert
 			convert_to_state_confirmation.popup_centered()
 
 func _on_convert_to_state_confirmation_confirmed():

--- a/addons/imjp94.yafsm/scenes/StateMachineEditor.gd
+++ b/addons/imjp94.yafsm/scenes/StateMachineEditor.gd
@@ -310,7 +310,7 @@ func _gui_input(event):
 				if event.pressed and can_gui_context_menu:
 					context_menu.set_item_disabled(1, current_layer.state_machine.has_entry())
 					context_menu.set_item_disabled(2, current_layer.state_machine.has_exit())
-					context_menu.position = get_viewport().get_mouse_position()
+					context_menu.position = get_window().position + Vector2i(get_viewport().get_mouse_position())
 					context_menu.popup()
 
 func _input(event):
@@ -391,7 +391,7 @@ func _on_state_node_gui_input(event, node):
 				if event.pressed:
 					# State node context menu
 					_context_node = node
-					state_node_context_menu.position = get_viewport().get_mouse_position()
+					state_node_context_menu.position = get_window().position + Vector2i(get_viewport().get_mouse_position())
 					state_node_context_menu.popup()
 					state_node_context_menu.set_item_disabled(3, not (node.state is StateMachine))
 					accept_event()

--- a/addons/imjp94.yafsm/scenes/StateMachineEditor.gd
+++ b/addons/imjp94.yafsm/scenes/StateMachineEditor.gd
@@ -399,7 +399,7 @@ func _on_state_node_gui_input(event, node):
 					_context_node = node
 					state_node_context_menu.position = get_window().position + Vector2i(get_viewport().get_mouse_position())
 					state_node_context_menu.popup()
-					state_node_context_menu.set_item_disabled(3, not (node.state is StateMachine))
+					state_node_context_menu.set_item_disabled(4, not (node.state is StateMachine))
 					accept_event()
 
 func convert_to_state_machine(layer, node):

--- a/addons/imjp94.yafsm/scenes/StateNodeContextMenu.tscn
+++ b/addons/imjp94.yafsm/scenes/StateNodeContextMenu.tscn
@@ -1,15 +1,17 @@
 [gd_scene format=3 uid="uid://ccv81pntbud75"]
 
 [node name="StateNodeContextMenu" type="PopupMenu"]
-size = Vector2i(154, 100)
+size = Vector2i(154, 120)
 visible = true
-item_count = 4
+item_count = 5
 item_0/text = "Copy"
 item_0/id = 0
 item_1/text = "Duplicate"
 item_1/id = 1
-item_2/text = ""
-item_2/id = 2
-item_2/separator = true
-item_3/text = "Convert to State"
-item_3/id = 3
+item_2/text = "Delete"
+item_2/id = 4
+item_3/text = ""
+item_3/id = 2
+item_3/separator = true
+item_4/text = "Convert to State"
+item_4/id = 3

--- a/addons/imjp94.yafsm/scenes/flowchart/FlowChart.gd
+++ b/addons/imjp94.yafsm/scenes/flowchart/FlowChart.gd
@@ -240,9 +240,11 @@ func _draw():
 	# 	draw_line(from_pos, to_pos, Color.yellow)
 
 func _gui_input(event):
+
+	var OS_KEY_DELETE = KEY_BACKSPACE if ( ["macOS", "OSX"].has(OS.get_name()) ) else KEY_DELETE
 	if event is InputEventKey:
 		match event.keycode:
-			KEY_DELETE:
+			OS_KEY_DELETE:
 				if event.pressed and can_gui_delete_node:
 					# Delete nodes
 					for node in _selection.duplicate():

--- a/addons/imjp94.yafsm/scenes/flowchart/FlowChartGrid.gd
+++ b/addons/imjp94.yafsm/scenes/flowchart/FlowChartGrid.gd
@@ -6,24 +6,30 @@ func _ready():
     flowchart = get_parent().get_parent()
     queue_redraw()
 
+# Original Draw in FlowChart.gd inspired by:
+# https://github.com/godotengine/godot/blob/6019dab0b45e1291e556e6d9e01b625b5076cc3c/scene/gui/graph_edit.cpp#L442
 func _draw():
-    self.position = flowchart.position
-    self.size = flowchart.size*100  # good with min_zoom = 0.5 e max_zoom = 2.0
 
-    # Original Draw in FlowChart.gd inspired by:
-	# https://github.com/godotengine/godot/blob/6019dab0b45e1291e556e6d9e01b625b5076cc3c/scene/gui/graph_edit.cpp#L442
+    self.position = flowchart.position
+    # Extents of the grid.
+    self.size = flowchart.size*100  # good with min_zoom = 0.5 e max_zoom = 2.0
 
     var zoom = flowchart.zoom
     var snap = flowchart.snap
 
+    # Origin of the grid. 
     var offset = -Vector2(1, 1)*10000  # good with min_zoom = 0.5 e max_zoom = 2.0
+    
     var corrected_size = size/zoom
 
-    var from = (offset / float(snap)).floor()
-    var l = (corrected_size / float(snap)).floor() + Vector2(1, 1)
+    var from = (offset / snap).floor()
+    var l = (corrected_size / snap).floor() + Vector2(1, 1)
 
     var grid_minor = flowchart.grid_minor_color
     var grid_major = flowchart.grid_major_color
+
+    var multi_line_vector_array: PackedVector2Array = PackedVector2Array()
+    var multi_line_color_array: PackedColorArray  = PackedColorArray ()
 
     # for (int i = from.x; i < from.x + len.x; i++) {
     for i in range(from.x, from.x + l.x):
@@ -35,11 +41,15 @@ func _draw():
             color = grid_minor
 
         var base_ofs = i * snap
-        draw_line(Vector2(base_ofs, offset.y), Vector2(base_ofs, corrected_size.y), color, -1, true)
+
+        multi_line_vector_array.append(Vector2(base_ofs, offset.y))
+        multi_line_color_array.append(color)
+        multi_line_vector_array.append(Vector2(base_ofs, corrected_size.y))
+        multi_line_color_array.append(color)
 
     # for (int i = from.y; i < from.y + len.y; i++) {
     for i in range(from.y, from.y + l.y):
-        var color;
+        var color
 
         if (int(abs(i)) % 10 == 0):
             color = grid_major
@@ -47,4 +57,10 @@ func _draw():
             color = grid_minor
 
         var base_ofs = i * snap
-        draw_line(Vector2(offset.x, base_ofs), Vector2(corrected_size.x, base_ofs), color, -1, true)
+
+        multi_line_vector_array.append(Vector2(offset.x, base_ofs))
+        multi_line_color_array.append(color)
+        multi_line_vector_array.append(Vector2(corrected_size.x, base_ofs))
+        multi_line_color_array.append(color)
+
+    draw_multiline_colors(multi_line_vector_array, multi_line_color_array, -1)

--- a/addons/imjp94.yafsm/scenes/state_nodes/StateNode.tscn
+++ b/addons/imjp94.yafsm/scenes/state_nodes/StateNode.tscn
@@ -1,6 +1,7 @@
-[gd_scene load_steps=7 format=3 uid="uid://l3mqbqjwjkc3"]
+[gd_scene load_steps=8 format=3 uid="uid://l3mqbqjwjkc3"]
 
 [ext_resource type="Script" path="res://addons/imjp94.yafsm/scenes/state_nodes/StateNode.gd" id="2"]
+[ext_resource type="SystemFont" uid="uid://dmcxm8gxsonbq" path="res://addons/imjp94.yafsm/assets/fonts/sans_serif.tres" id="2_352m3"]
 
 [sub_resource type="StyleBoxFlat" id="1"]
 bg_color = Color(0.164706, 0.164706, 0.164706, 1)
@@ -44,38 +45,35 @@ border_width_bottom = 3
 shadow_size = 2
 
 [sub_resource type="Theme" id="5"]
-FlowChartNode/styles/focus = SubResource( "1" )
-FlowChartNode/styles/normal = SubResource( "2" )
-StateNode/styles/nested_focus = SubResource( "3" )
-StateNode/styles/nested_normal = SubResource( "4" )
+FlowChartNode/styles/focus = SubResource("1")
+FlowChartNode/styles/normal = SubResource("2")
+StateNode/styles/nested_focus = SubResource("3")
+StateNode/styles/nested_normal = SubResource("4")
 
 [node name="StateNode" type="HBoxContainer"]
 grow_horizontal = 2
 grow_vertical = 2
-theme = SubResource( "5" )
-script = ExtResource( "2" )
+theme = SubResource("5")
+script = ExtResource("2")
 
 [node name="MarginContainer" type="MarginContainer" parent="."]
-offset_right = 77.0
-offset_bottom = 41.0
+layout_mode = 2
 mouse_filter = 2
-theme_override_constants/margin_right = 5
-theme_override_constants/margin_top = 5
 theme_override_constants/margin_left = 5
+theme_override_constants/margin_top = 5
+theme_override_constants/margin_right = 5
 theme_override_constants/margin_bottom = 5
 
 [node name="NameEdit" type="LineEdit" parent="MarginContainer"]
-offset_left = 4.0
-offset_top = 5.0
-offset_right = 71.0625
-offset_bottom = 36.0
+layout_mode = 2
 size_flags_horizontal = 4
 size_flags_vertical = 4
 mouse_filter = 2
 mouse_default_cursor_shape = 0
+theme_override_fonts/font = ExtResource("2_352m3")
 text = "State"
+alignment = 1
 editable = false
 expand_to_text_length = true
 selecting_enabled = false
 caret_blink = true
-caret_blink_speed = 0.5

--- a/addons/imjp94.yafsm/scenes/transition_editors/TransitionEditor.gd
+++ b/addons/imjp94.yafsm/scenes/transition_editors/TransitionEditor.gd
@@ -38,8 +38,9 @@ func _ready():
 	priority_spinbox.value_changed.connect(_on_priority_spinbox_value_changed)
 	add.pressed.connect(_on_add_pressed)
 	add_popup_menu.index_pressed.connect(_on_add_popup_menu_index_pressed)
-	
-	priority_icon.texture = get_theme_icon("AnimationTrackList", "EditorIcons")
+
+	condition_count_icon.texture = get_theme_icon("MirrorX", "EditorIcons")
+	priority_icon.texture = get_theme_icon("AnimationTrackGroup", "EditorIcons")
 
 func _exit_tree():
 	free_node_from_undo_redo() # Managed by EditorInspector

--- a/addons/imjp94.yafsm/scenes/transition_editors/TransitionEditor.tscn
+++ b/addons/imjp94.yafsm/scenes/transition_editors/TransitionEditor.tscn
@@ -1,11 +1,18 @@
 [gd_scene load_steps=7 format=3 uid="uid://dw0ecw2wdeosi"]
 
 [ext_resource type="Texture2D" uid="uid://dg8cmn5ubq6r5" path="res://addons/imjp94.yafsm/assets/icons/add-white-18dp.svg" id="1"]
-[ext_resource type="Texture2D" uid="uid://b2coah58shtq1" path="res://addons/imjp94.yafsm/assets/icons/subdirectory_arrow_right-white-18dp.svg" id="2"]
 [ext_resource type="Script" path="res://addons/imjp94.yafsm/scenes/transition_editors/TransitionEditor.gd" id="3"]
-[ext_resource type="Texture2D" uid="uid://cnkaa2ky1f4jq" path="res://addons/imjp94.yafsm/assets/icons/compare_arrows-white-18dp.svg" id="4"]
 
-[sub_resource type="Image" id="Image_oefu4"]
+[sub_resource type="Gradient" id="Gradient_hw7k8"]
+offsets = PackedFloat32Array(1)
+colors = PackedColorArray(1, 1, 1, 1)
+
+[sub_resource type="GradientTexture2D" id="GradientTexture2D_ipxab"]
+gradient = SubResource("Gradient_hw7k8")
+width = 18
+height = 18
+
+[sub_resource type="Image" id="Image_o35y7"]
 data = {
 "data": PackedByteArray(255, 255, 255, 0, 255, 255, 255, 0, 255, 128, 128, 4, 255, 128, 128, 4, 255, 128, 128, 4, 255, 128, 128, 4, 255, 128, 128, 4, 255, 128, 128, 4, 255, 128, 128, 4, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 93, 93, 131, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 131, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 131, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 93, 93, 252, 255, 93, 93, 252, 255, 93, 93, 252, 255, 94, 94, 127, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 128, 128, 4, 255, 128, 128, 4, 255, 128, 128, 4, 255, 128, 128, 4, 255, 128, 128, 4, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 231, 255, 93, 93, 55, 255, 97, 97, 58, 255, 93, 93, 233, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 231, 255, 94, 94, 54, 255, 94, 94, 57, 255, 93, 93, 233, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 97, 97, 42, 255, 255, 255, 0, 255, 255, 255, 0, 255, 97, 97, 42, 255, 93, 93, 233, 255, 93, 93, 232, 255, 93, 93, 41, 255, 255, 255, 0, 255, 255, 255, 0, 255, 97, 97, 42, 255, 93, 93, 233, 255, 93, 93, 232, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 96, 96, 45, 255, 97, 97, 42, 255, 255, 255, 0, 255, 97, 97, 42, 255, 97, 97, 42, 255, 255, 255, 0, 255, 98, 98, 47, 255, 97, 97, 42, 255, 255, 255, 0, 255, 97, 97, 42, 255, 97, 97, 42, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 96, 96, 45, 255, 93, 93, 235, 255, 93, 93, 233, 255, 97, 97, 42, 255, 255, 255, 0, 255, 255, 255, 0, 255, 94, 94, 46, 255, 93, 93, 236, 255, 93, 93, 233, 255, 97, 97, 42, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 235, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 233, 255, 95, 95, 59, 255, 96, 96, 61, 255, 93, 93, 235, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 233, 255, 95, 95, 59, 255, 96, 96, 61, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 252, 255, 93, 93, 252, 255, 93, 93, 252, 255, 93, 93, 252, 255, 93, 93, 252, 255, 93, 93, 252, 255, 93, 93, 252, 255, 93, 93, 252, 255, 93, 93, 252, 255, 93, 93, 252, 255, 93, 93, 252, 255, 93, 93, 252, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0),
 "format": "RGBA8",
@@ -14,136 +21,89 @@ data = {
 "width": 16
 }
 
-[sub_resource type="ImageTexture" id="ImageTexture_fhm6b"]
-image = SubResource("Image_oefu4")
+[sub_resource type="ImageTexture" id="ImageTexture_v636r"]
+image = SubResource("Image_o35y7")
 
 [node name="TransitionEditor" type="VBoxContainer"]
 script = ExtResource("3")
 
 [node name="HeaderContainer" type="MarginContainer" parent="."]
 layout_mode = 2
-offset_right = 300.0
-offset_bottom = 31.0
 
 [node name="Panel" type="Panel" parent="HeaderContainer"]
 layout_mode = 2
-offset_right = 300.0
-offset_bottom = 31.0
 
 [node name="Header" type="HBoxContainer" parent="HeaderContainer"]
 layout_mode = 2
-offset_right = 300.0
-offset_bottom = 31.0
 
 [node name="Title" type="HBoxContainer" parent="HeaderContainer/Header"]
 layout_mode = 2
-offset_right = 86.0
-offset_bottom = 31.0
 tooltip_text = "Next State"
 
 [node name="From" type="Label" parent="HeaderContainer/Header/Title"]
 layout_mode = 2
-offset_top = 2.0
-offset_right = 41.0
-offset_bottom = 28.0
 size_flags_horizontal = 3
 text = "From"
 
 [node name="Icon" type="TextureRect" parent="HeaderContainer/Header/Title"]
+texture_filter = 1
 layout_mode = 2
-offset_left = 45.0
-offset_right = 63.0
-offset_bottom = 31.0
-texture = ExtResource("2")
-stretch_mode = 6
+texture = SubResource("GradientTexture2D_ipxab")
+expand_mode = 3
+stretch_mode = 3
 
 [node name="To" type="Label" parent="HeaderContainer/Header/Title"]
 layout_mode = 2
-offset_left = 67.0
-offset_top = 2.0
-offset_right = 86.0
-offset_bottom = 28.0
 size_flags_horizontal = 3
 text = "To"
 
 [node name="VSeparator" type="VSeparator" parent="HeaderContainer/Header"]
 layout_mode = 2
-offset_left = 90.0
-offset_right = 94.0
-offset_bottom = 31.0
 
 [node name="ConditionCount" type="HBoxContainer" parent="HeaderContainer/Header"]
 layout_mode = 2
-offset_left = 98.0
-offset_right = 147.0
-offset_bottom = 31.0
-tooltip_text = "Number of Condition"
+tooltip_text = "Number of Conditions"
 
 [node name="Icon" type="TextureRect" parent="HeaderContainer/Header/ConditionCount"]
+texture_filter = 1
 layout_mode = 2
-offset_top = 6.0
-offset_right = 18.0
-offset_bottom = 24.0
-size_flags_horizontal = 4
-size_flags_vertical = 4
-texture = ExtResource("4")
+texture = SubResource("ImageTexture_v636r")
+expand_mode = 3
+stretch_mode = 3
 
 [node name="Label" type="Label" parent="HeaderContainer/Header/ConditionCount"]
 layout_mode = 2
-offset_left = 22.0
-offset_top = 2.0
-offset_right = 49.0
-offset_bottom = 28.0
 text = "No."
 
 [node name="VSeparator2" type="VSeparator" parent="HeaderContainer/Header"]
 layout_mode = 2
-offset_left = 151.0
-offset_right = 155.0
-offset_bottom = 31.0
 
 [node name="Priority" type="HBoxContainer" parent="HeaderContainer/Header"]
 layout_mode = 2
-offset_left = 159.0
-offset_right = 262.0
-offset_bottom = 31.0
 tooltip_text = "Priority"
 
 [node name="Icon" type="TextureRect" parent="HeaderContainer/Header/Priority"]
+texture_filter = 1
 layout_mode = 2
-offset_top = 7.0
-offset_right = 16.0
-offset_bottom = 23.0
-size_flags_horizontal = 4
-size_flags_vertical = 4
-texture = SubResource("ImageTexture_fhm6b")
+texture = SubResource("ImageTexture_v636r")
+expand_mode = 3
+stretch_mode = 3
 
 [node name="SpinBox" type="SpinBox" parent="HeaderContainer/Header/Priority"]
 layout_mode = 2
-offset_left = 20.0
-offset_right = 103.0
-offset_bottom = 31.0
 max_value = 10.0
 rounded = true
 allow_greater = true
 
 [node name="VSeparator3" type="VSeparator" parent="HeaderContainer/Header"]
 layout_mode = 2
-offset_left = 266.0
-offset_right = 270.0
-offset_bottom = 31.0
 
 [node name="HBoxContainer" type="HBoxContainer" parent="HeaderContainer/Header"]
 layout_mode = 2
-offset_left = 274.0
-offset_right = 300.0
-offset_bottom = 31.0
 size_flags_horizontal = 10
 
 [node name="Add" type="Button" parent="HeaderContainer/Header/HBoxContainer"]
 layout_mode = 2
-offset_right = 26.0
-offset_bottom = 31.0
 tooltip_text = "Add Condition"
 icon = ExtResource("1")
 flat = true
@@ -163,16 +123,11 @@ item_4/id = 4
 
 [node name="MarginContainer" type="MarginContainer" parent="."]
 layout_mode = 2
-offset_top = 35.0
-offset_right = 300.0
-offset_bottom = 35.0
 
 [node name="Panel" type="Panel" parent="MarginContainer"]
 layout_mode = 2
-offset_right = 300.0
 size_flags_horizontal = 3
 size_flags_vertical = 3
 
 [node name="Conditions" type="VBoxContainer" parent="MarginContainer"]
 layout_mode = 2
-offset_right = 300.0

--- a/addons/imjp94.yafsm/scenes/transition_editors/TransitionLine.gd
+++ b/addons/imjp94.yafsm/scenes/transition_editors/TransitionLine.gd
@@ -3,6 +3,8 @@ extends "res://addons/imjp94.yafsm/scenes/flowchart/FlowChartLine.gd"
 const Transition = preload("../../src/transitions/Transition.gd")
 const ValueCondition = preload("../../src/conditions/ValueCondition.gd")
 
+const hi_res_font: Font = preload("res://addons/imjp94.yafsm/assets/hi-res-font.tres")
+
 @export var upright_angle_range: = 5.0
 
 @onready var label_margin = $MarginContainer
@@ -55,6 +57,7 @@ func update_label():
 			if not label:
 				label = Label.new()
 				label.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
+				label.add_theme_font_override("font", hi_res_font)
 				label.name = condition.name
 				vbox.add_child(label)
 			if "value" in condition:

--- a/addons/imjp94.yafsm/scenes/transition_editors/TransitionLine.tscn
+++ b/addons/imjp94.yafsm/scenes/transition_editors/TransitionLine.tscn
@@ -1,32 +1,26 @@
-[gd_scene load_steps=3 format=3 uid="uid://cwb2nrjai7fao"]
+[gd_scene load_steps=4 format=3 uid="uid://cwb2nrjai7fao"]
 
 [ext_resource type="PackedScene" uid="uid://creoglbeckyhs" path="res://addons/imjp94.yafsm/scenes/flowchart/FlowChartLine.tscn" id="1"]
 [ext_resource type="Script" path="res://addons/imjp94.yafsm/scenes/transition_editors/TransitionLine.gd" id="2"]
+[ext_resource type="SystemFont" uid="uid://dmcxm8gxsonbq" path="res://addons/imjp94.yafsm/assets/fonts/sans_serif.tres" id="3_y6xyv"]
 
 [node name="TransitionLine" instance=ExtResource("1")]
 script = ExtResource("2")
 upright_angle_range = 0.0
 
 [node name="MarginContainer" type="MarginContainer" parent="." index="0"]
-offset_left = -39.5
-offset_top = -26.0
-offset_right = 39.5
-grow_horizontal = 0
-grow_vertical = 0
+layout_mode = 2
 mouse_filter = 2
 
 [node name="Label" type="Label" parent="MarginContainer" index="0"]
 visible = false
-offset_right = 79.0
-offset_bottom = 26.0
+layout_mode = 2
 size_flags_horizontal = 6
 size_flags_vertical = 6
+theme_override_fonts/font = ExtResource("3_y6xyv")
 text = "Transition"
 
 [node name="VBoxContainer" type="VBoxContainer" parent="MarginContainer" index="1"]
-offset_left = 39.0
-offset_top = 13.0
-offset_right = 39.0
-offset_bottom = 13.0
+layout_mode = 2
 size_flags_horizontal = 4
 size_flags_vertical = 4

--- a/addons/imjp94.yafsm/scripts/Utils.gd
+++ b/addons/imjp94.yafsm/scripts/Utils.gd
@@ -1,5 +1,5 @@
 # Position Popup near to its target while within window, solution from ColorPickerButton source code(https://github.com/godotengine/godot/blob/6d8c14f849376905e1577f9fc3f9512bcffb1e3c/scene/gui/color_picker.cpp#L878)
-static func popup_on_target(popup, target):
+static func popup_on_target(popup: Popup, target: Control):
 	popup.reset_size()
 	var usable_rect = Rect2(Vector2.ZERO, DisplayServer.window_get_size_with_decorations())
 	var cp_rect = Rect2(Vector2.ZERO, popup.get_size())
@@ -16,7 +16,9 @@ static func popup_on_target(popup, target):
 
 		if usable_rect.encloses(cp_rect):
 			break
-	popup.set_position(cp_rect.position)
+	var main_window_position = DisplayServer.window_get_position()
+	var popup_position = main_window_position + Vector2i(cp_rect.position)  # make it work in multi-screen setups
+	popup.set_position(popup_position)
 	popup.popup()
 
 static func get_complementary_color(color):


### PR DESCRIPTION
Should fix #52, #57 AND address the occasional graphical glitches, with vastly improved performance thanks to the `draw_multiline_colors()` function.

Also includes:
- a fix for the context menu in multi-monitor setup: it used to open in the wrong place when opened in the secondary monitor
- the workaround for the node deletion issue suggested by @DSPerson in [this comment](https://github.com/imjp94/gd-YAFSM/issues/52#issuecomment-1537032852) - strange that the KEY_DELETE event is not read though, what key are you pressing  on your mac @DSPerson?