### PR TITLE
Allow StateMachinePlayer to be inherited

### DIFF
--- a/addons/imjp94.yafsm/plugin.gd
+++ b/addons/imjp94.yafsm/plugin.gd
@@ -111,6 +111,8 @@ func _on_focused_object_changed(new_obj):
 		if focused_object is StateMachinePlayer:
 			if focused_object.get_class() == "EditorDebuggerRemoteObject":
 				state_machine = focused_object.get("Members/state_machine")
+				if state_machine == null:
+					state_machine = focused_object.get("Members/StateMachinePlayer.gd/state_machine")
 			else:
 				state_machine = focused_object.state_machine
 			state_machine_editor.state_machine_player = focused_object

--- a/addons/imjp94.yafsm/src/StateMachinePlayer.gd
+++ b/addons/imjp94.yafsm/src/StateMachinePlayer.gd
@@ -1,5 +1,5 @@
 @tool
-extends "StackPlayer.gd"
+class_name StateMachinePlayer extends "StackPlayer.gd"
 
 signal transited(from, to) # Transition of state
 signal entered(to) # Entry of state machine(including nested), empty string equals to root


### PR DESCRIPTION
Added class_name to StateMachinePlayer to allow reaching the class without have to preload it in every script.

This also allows it to extends a custom class to StateMachinePlayer. And when you do this, the Debugger breaks, so the commit also fix it trying to reach the state_machine property by "Members/StateMachinePlayer.gd/state_machine" path.

Tested in Godot 4.2 and 4.3