### PR TITLE
Puts a little arrow in front of trigger.

### DIFF
--- a/addons/imjp94.yafsm/scenes/transition_editors/TransitionLine.gd
+++ b/addons/imjp94.yafsm/scenes/transition_editors/TransitionLine.gd
@@ -69,7 +69,7 @@ func update_label():
 				if override_template_var:
 					label.text = label.text.format(override_template_var)
 			else:
-				label.text = condition.name
+				label.text = "→ %s" % condition.name
 	queue_redraw()
 
 func _on_transition_changed(new_transition):


### PR DESCRIPTION
To clarify that this condition is a trigger an arrow is rendered in front of the trigger name in the label.