### PR TITLE
While debugging explicitly formats float values.

### DIFF
--- a/addons/imjp94.yafsm/scenes/StateMachineEditorLayer.gd
+++ b/addons/imjp94.yafsm/scenes/StateMachineEditorLayer.gd
@@ -44,7 +44,7 @@ func debug_update(current_state, parameters, local_parameters):
 				if not ("value" in condition): # Ignore trigger
 					continue
 				var value = parameters.get(str(condition.name))
-				value = str(value) if value != null else "?"
+				value = condition.get_formatted_value(value) if value != null else "?"
 				var label = line.vbox.get_node_or_null(NodePath(str(condition.name)))
 				var override_template_var = line._template_var.get(str(condition.name))
 				if override_template_var == null:
@@ -123,7 +123,7 @@ func debug_transit_in(from, to):
 	# Change string template for current TransitionLines
 	for transition in transitions.values():
 		var line = content_lines.get_node_or_null(NodePath("%s>%s" % [transition.from, transition.to]))
-		line.template = "{condition_name} {condition_comparation} {condition_value}({value})"
+		line.template = "{condition_name} {condition_comparation} {condition_value} ({value})"
 	_start_tweens()
 
 func set_editor_accent_color(color):

--- a/addons/imjp94.yafsm/src/conditions/FloatCondition.gd
+++ b/addons/imjp94.yafsm/src/conditions/FloatCondition.gd
@@ -19,6 +19,9 @@ func get_value():
 func get_value_string():
 	return str(snapped(value, 0.01)).pad_decimals(2)
 
+func get_formatted_value(value):
+	return str(snapped(value, 0.01)).pad_decimals(2)
+
 func compare(v):
 	if typeof(v) != TYPE_FLOAT:
 		return false

--- a/addons/imjp94.yafsm/src/conditions/ValueCondition.gd
+++ b/addons/imjp94.yafsm/src/conditions/ValueCondition.gd
@@ -49,6 +49,10 @@ func get_value():
 func get_value_string():
 	return get_value()
 
+# Can be used to format a provided value
+func get_formatted_value(value):
+	return value
+
 # Compare value against this condition, return true if succeeded
 func compare(v):
 	if v == null:


### PR DESCRIPTION
Currently float values that are used in a float condition are formatted to two decimals when rendering the condition itself. The debugger would render the actual float value with full precision, often leading to a label that would jump wildly visually. Now you can format such values explicitly too.

Also adds a space between condition_value and the (value).