### PR TITLE
Fix debug remote not work post Godot 4.4.1.

### DIFF
--- a/addons/imjp94.yafsm/plugin.gd
+++ b/addons/imjp94.yafsm/plugin.gd
@@ -66,7 +66,7 @@ func _handles(object):
 		_handled_and_ready_to_edit = true  # this should not be necessary, but it seemingly is (Godot 4.0-rc1)
 		return true  # when return true from _handles, _edit can proceed.
 	if object is StateMachinePlayer:
-		if object.get_class() == "EditorDebuggerRemoteObject":
+		if object.get_class() == "EditorDebuggerRemoteObjects":
 			set_focused_object(object)
 			state_machine_editor.debug_mode = true
 			return false
@@ -106,7 +106,7 @@ func _on_focused_object_changed(new_obj):
 		show_state_machine_editor()
 		var state_machine
 		if focused_object is StateMachinePlayer:
-			if focused_object.get_class() == "EditorDebuggerRemoteObject":
+			if focused_object.get_class() == "EditorDebuggerRemoteObjects":
 				state_machine = focused_object.get("Members/state_machine")
 				if state_machine == null:
 					state_machine = focused_object.get("Members/StateMachinePlayer.gd/state_machine")

--- a/addons/imjp94.yafsm/scenes/StateMachineEditor.gd
+++ b/addons/imjp94.yafsm/scenes/StateMachineEditor.gd
@@ -296,7 +296,7 @@ func _on_debug_mode_changed(new_debug_mode):
 func _on_state_machine_player_changed(new_state_machine_player):
 	if not state_machine_player:
 		return
-	if new_state_machine_player.get_class() == "EditorDebuggerRemoteObject":
+	if new_state_machine_player.get_class() == "EditorDebuggerRemoteObjects":
 		return
 
 	if new_state_machine_player:


### PR DESCRIPTION
Fix https://github.com/imjp94/gd-YAFSM/issues/92
Rename `EditorDebuggerRemoteObject` to `EditorDebuggerRemoteObjects` with https://github.com/godotengine/godot/commit/20651f1162b348c7e61d49d07f03baa423ad68d6