### PR TITLE
Fix transition priority reverting in inspector

### DIFF
--- a/addons/imjp94.yafsm/scenes/transition_editors/TransitionEditor.gd
+++ b/addons/imjp94.yafsm/scenes/transition_editors/TransitionEditor.gd
@@ -27,6 +27,7 @@ var transition:
 	set = set_transition
 
 var _to_free
+var _is_syncing_priority := false
 
 
 func _init():
@@ -50,6 +51,8 @@ func _on_header_gui_input(event):
 			toggle_conditions()
 
 func _on_priority_spinbox_value_changed(val: int) -> void:
+	if _is_syncing_priority:
+		return
 	set_priority(val)
 
 func _on_add_pressed():
@@ -128,8 +131,9 @@ func update_condition_count():
 		show_conditions()
 
 func update_priority_spinbox_value():
-	priority_spinbox.value = transition.priority
-	priority_spinbox.apply()
+	_is_syncing_priority = true
+	priority_spinbox.set_value_no_signal(transition.priority)
+	_is_syncing_priority = false
 	
 func set_priority(value):
 	transition.priority = value


### PR DESCRIPTION
## Summary
- prevent the transition priority SpinBox from emitting `value_changed` while the inspector is syncing UI from a selected `Transition`
- use `set_value_no_signal()` in `update_priority_spinbox_value()` so refreshes do not write default values back into the resource
- this fixes a regression where editing a transition's `priority` reverts immediately in the YAFSM editor

## Test plan
- [x] Open a state machine with multiple transitions from the same `from` state
- [x] Set one transition's priority in the YAFSM transition inspector
- [x] Re-select the transition and verify the priority value persists instead of snapping back
- [x] Save scene/resource and run game; confirm transition ordering respects the edited priority

Made with [Cursor](https://cursor.com)